### PR TITLE
不忽略时间戳相同的rtp包

### DIFF
--- a/librtp/payload/rtp-payload-helper.c
+++ b/librtp/payload/rtp-payload-helper.c
@@ -51,7 +51,7 @@ int rtp_payload_check(struct rtp_payload_helper_t* helper, const struct rtp_pack
 	helper->seq = (uint16_t)pkt->rtp.seq;
 
 	// check timestamp
-	if (pkt->rtp.timestamp != helper->timestamp)
+//	if (pkt->rtp.timestamp != helper->timestamp)
 	{
 		rtp_payload_onframe(helper);
 	}


### PR DESCRIPTION
实测发现, iptv中比较常见的rtp组播流负载是mpeg-ts,rtp的时间戳一般为零 ，它们有效的时间戳在ts负载里面