### PR TITLE
Allow multiple SPS & PPS to be recognized at a time.

### DIFF
--- a/libflv/source/mpeg4-annexbtomp4.c
+++ b/libflv/source/mpeg4-annexbtomp4.c
@@ -264,11 +264,11 @@ static void h264_handler(void* param, const void* nalu, size_t bytes)
 			mp4->avc->compatibility = ((uint8_t*)nalu)[2];
 			mp4->avc->level = ((uint8_t*)nalu)[3];
 		}
-		return;
+        break;
 
 	case H264_NAL_PPS:
 		h264_pps_copy(mp4, nalu, bytes);
-		return;
+        break;
 
 #if defined(H2645_FILTER_AUD)
 	case H264_NAL_AUD:


### PR DESCRIPTION
You can see here that, `FFmpeg` not only writes `SPS` & `PPS` as an `AVC sequence header`, but also as an `AVC NALU`. Specifically,
- `7745 = 7719 + 4(=length) + 14(=SPS0) + 4(=length) + 4(=PPS0)` and 
- `5157 = 5130 + 4(=length) + 15(=SPS1) + 4(=length) + 4(=PPS1)`.

![1](https://user-images.githubusercontent.com/53786979/69028630-ef15dd80-0a15-11ea-8a78-863389dafdad.png)
![3](https://user-images.githubusercontent.com/53786979/69028666-05239e00-0a16-11ea-901d-68113d01436d.png)

However, `libflv` skips doing so, thereby losing the second `SPS` & `PPS`:

![2](https://user-images.githubusercontent.com/53786979/69028658-00f78080-0a16-11ea-91d2-e68800d61baf.png)
![4](https://user-images.githubusercontent.com/53786979/69028647-fb019f80-0a15-11ea-8d3d-a0de2fa65181.png)

Here, I made a change so that `libflv` follows the `FFmpeg`'s behavior.