### PR TITLE
fix mp4 seek debug;

### DIFF
--- a/libmov/source/mov-reader.c
+++ b/libmov/source/mov-reader.c
@@ -520,7 +520,7 @@ static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp)
 			assert(0);
 			return -1;
 		}
-
+		idx -= 1;
 		sample = &track->samples[idx - 1];
 		
 		if (sample->dts > clock)

--- a/libmov/source/mov-reader.c
+++ b/libmov/source/mov-reader.c
@@ -521,7 +521,7 @@ static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp)
 			return -1;
 		}
 		idx -= 1;
-		sample = &track->samples[idx - 1];
+		sample = &track->samples[idx];
 		
 		if (sample->dts > clock)
 			end = mid;


### PR DESCRIPTION
media-server/libmov/source/mov-reader.c里面的mov_stss_seek函数中，当对prev和next进行DIFF都不匹配时，应该将idx减1