### PR TITLE
Free rtmp client resource when destroy.

### DIFF
--- a/librtmp/aio/aio-rtmp-client.c
+++ b/librtmp/aio/aio-rtmp-client.c
@@ -173,5 +173,7 @@ static void aio_rtmp_transport_ondestroy(void* param)
 	client = (struct aio_rtmp_client_t*)param;
 	if (client->handler.ondestroy)
 		client->handler.ondestroy(client->param);
+	if (client->rtmp)
+		rtmp_client_destroy(client->rtmp);
 	free(client);
 }


### PR DESCRIPTION
When using "aio rtmp client" utilities, "rtmp client" resources is not destroyed when destroy "aio rtmp client", which leads to resource leak(memory leak) for each "aio rtmp client" usage.
Try to free "client->rtmp" after user specified ondestroy function call, to allow user to get some possible process done to the "client->rtmp".