### PR TITLE
skip rtmp message that has no transactionId

### DIFF
--- a/librtmp/source/rtmp-invoke-handler.c
+++ b/librtmp/source/rtmp-invoke-handler.c
@@ -262,8 +262,10 @@ int rtmp_invoke_handler(struct rtmp_t* rtmp, const struct rtmp_chunk_header_t* h
 	AMF_OBJECT_ITEM_VALUE(items[1], AMF_NUMBER, "transactionId", &transaction, sizeof(double));
 
 	data = amf_read_items(data, end, items, sizeof(items) / sizeof(items[0]));
-	if (!data || -1.0 == transaction)
+	if (!data)
 		return EINVAL; // invalid data
+	if (-1.0 == transaction)
+		return 0; // no transactionId
 
 	for (i = 0; i < sizeof(s_command_handler) / sizeof(s_command_handler[0]); i++)
 	{


### PR DESCRIPTION
When rtmp client streaming to ffmpeg, ffmpeg wil send a onFCPublish without transactionid.
It would be skipped quietly.