### PR TITLE
fix undefined reference to ftello64 on Android.

### DIFF
--- a/libmov/test/mov-file-buffer.c
+++ b/libmov/test/mov-file-buffer.c
@@ -8,6 +8,9 @@
 #if defined(_WIN32) || defined(_WIN64)
 #define fseek64 _fseeki64
 #define ftell64 _ftelli64
+#elif defined(__ANDROID__)
+#define fseek64 fseek
+#define ftell64 ftell
 #elif defined(OS_LINUX)
 #define fseek64 fseeko64
 #define ftell64 ftello64


### PR DESCRIPTION
修复mov-file-buffer在安卓上没有fseeko64和ftello64的问题