### PR TITLE
add 265 media source

### DIFF
--- a/librtsp/test/media/h265-file-reader.cpp
+++ b/librtsp/test/media/h265-file-reader.cpp
@@ -1,0 +1,146 @@
+#include "h265-file-reader.h"
+#include <assert.h>
+#include <string.h>
+#include <algorithm>
+
+#define H265_NAL(v)	 ((v>> 1) & 0x3f)
+
+enum { NAL_IDR_W_RADL = 19, NAL_IDR_N_LP= 20, NAL_VPS = 32, NAL_SPS = 33, NAL_PPS = 34, NAL_SEI = 39};
+
+H265FileReader::H265FileReader(const char* file)
+:m_ptr(NULL), m_capacity(0)
+{
+	FILE* fp = fopen(file, "rb");
+    if(fp)
+    {
+		fseek(fp, 0, SEEK_END);
+		m_capacity = ftell(fp);
+		fseek(fp, 0, SEEK_SET);
+
+        m_ptr = (uint8_t*)malloc(m_capacity);
+		fread(m_ptr, 1, m_capacity, fp);
+		fclose(fp);
+
+		Init();
+    }
+
+	m_vit = m_videos.begin();
+}
+
+H265FileReader::~H265FileReader()
+{    
+	if (m_ptr)
+	{
+		assert(m_capacity > 0);
+		free(m_ptr);
+	}
+}
+
+bool H265FileReader::IsOpened() const
+{
+	return !m_videos.empty();
+}
+
+int H265FileReader::GetNextFrame(int64_t &dts, const uint8_t* &ptr, size_t &bytes)
+{
+	if(m_vit == m_videos.end())
+		return -1; // file end
+
+	ptr = m_vit->nalu;
+	dts = m_vit->time;
+	bytes = m_vit->bytes;
+
+	++m_vit;
+	return 0;
+}
+
+int H265FileReader::Seek(int64_t &dts)
+{
+	vframe_t frame;
+	frame.time = dts;
+
+	vframes_t::iterator it;
+	it = std::lower_bound(m_videos.begin(), m_videos.end(), frame);
+	if(it == m_videos.end())
+		return -1;
+
+	while(it != m_videos.begin())
+	{
+		if(it->idr)
+		{
+			m_vit = it;
+			return 0;
+		}
+		--it;
+	}
+	return 0;
+}
+
+static inline const uint8_t* search_start_code(const uint8_t* ptr, const uint8_t* end)
+{
+    for(const uint8_t *p = ptr; p + 3 < end; p++)
+    {
+        if(0x00 == p[0] && 0x00 == p[1] && (0x01 == p[2] || (0x00==p[2] && 0x01==p[3])))
+            return p;
+    }
+	return end;
+}
+
+static inline int h265_nal_type(const unsigned char* ptr)
+{
+    int i = 2;
+    assert(0x00 == ptr[0] && 0x00 == ptr[1]);
+    if(0x00 == ptr[2])
+        ++i;
+    assert(0x01 == ptr[i]);
+    return H265_NAL(ptr[i+1]);
+}
+
+
+int H265FileReader::Init()
+{
+    size_t count = 0;
+    bool vpsspspps = true;
+
+	const uint8_t* end = m_ptr + m_capacity;
+    const uint8_t* nalu = search_start_code(m_ptr, end);
+	const uint8_t* p = nalu;
+
+	while (p < end)
+	{
+        const unsigned char* pn = search_start_code(p + 4, end);
+		size_t bytes = pn - nalu;
+
+        int nal_unit_type = h265_nal_type(p);
+		assert(0 <= nal_unit_type);
+
+        if(NAL_VPS == nal_unit_type || NAL_SPS == nal_unit_type || NAL_PPS == nal_unit_type)
+        {
+            if(vpsspspps)
+            {
+                size_t n = 0x01 == p[2] ? 3 : 4;
+				std::pair<const uint8_t*, size_t> pr;
+				pr.first = p + n;
+				pr.second = bytes;
+				m_sps.push_back(pr);
+            }
+        }
+		
+        {
+            if(m_sps.size() > 0) vpsspspps = false; // don't need more vps/sps/pps
+
+			vframe_t frame;
+			frame.nalu = nalu;
+			frame.bytes = bytes;
+			frame.time = 40 * count++;
+			frame.idr = (NAL_IDR_N_LP == nal_unit_type || NAL_IDR_W_RADL == nal_unit_type); // IDR-frame
+			m_videos.push_back(frame);
+			nalu = pn;
+        }
+
+        p = pn;
+    }
+
+    m_duration = 40 * count;
+    return 0;
+}

--- a/librtsp/test/media/h265-file-reader.h
+++ b/librtsp/test/media/h265-file-reader.h
@@ -1,0 +1,51 @@
+#ifndef _h265_file_reader_h_
+#define _h265_file_reader_h_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <list>
+#include "ctypedef.h"
+
+class H265FileReader
+{
+public:
+	H265FileReader(const char* file);
+	~H265FileReader();
+
+	bool IsOpened() const;
+
+public:
+    const std::list<std::pair<const uint8_t*, size_t> > GetParameterSets() const { return m_sps; }
+	int GetDuration(int64_t& duration) const { duration = m_duration; return 0; }
+    int GetNextFrame(int64_t &dts, const uint8_t* &ptr, size_t &bytes);
+	int Seek(int64_t &dts);
+
+private:
+	int Init();
+
+private:
+	struct vframe_t
+	{
+		const uint8_t* nalu;
+		int64_t time;
+		long bytes;
+		bool idr; // IDR frame
+
+		bool operator < (const struct vframe_t &v) const
+		{
+			return time < v.time;
+		}
+	};
+    typedef std::vector<vframe_t> vframes_t;
+    vframes_t m_videos;
+	vframes_t::iterator m_vit;
+
+    std::list<std::pair<const uint8_t*, size_t> > m_sps;
+	int64_t m_duration;
+
+    uint8_t *m_ptr;
+    size_t m_capacity;
+};
+
+#endif /* !_h265_file_reader_h_ */

--- a/librtsp/test/media/h265-file-source.cpp
+++ b/librtsp/test/media/h265-file-source.cpp
@@ -1,0 +1,216 @@
+#include "h265-file-source.h"
+#include "cstringext.h"
+#include "base64.h"
+#include "rtp-profile.h"
+#include "rtp-payload.h"
+#include <assert.h>
+
+extern "C" uint32_t rtp_ssrc(void);
+
+H265FileSource::H265FileSource(const char *file)
+:m_reader(file)
+{
+	m_speed = 1.0;
+	m_status = 0;
+	m_rtp_clock = 0;
+	m_rtcp_clock = 0;
+	m_timestamp = 0;
+
+	uint32_t ssrc = rtp_ssrc();
+	static struct rtp_payload_t s_rtpfunc = {
+		H265FileSource::RTPAlloc,
+		H265FileSource::RTPFree,
+		H265FileSource::RTPPacket,
+	};
+	m_rtppacker = rtp_payload_encode_create(RTP_PAYLOAD_H265, "H265", (uint16_t)ssrc, ssrc, &s_rtpfunc, this);
+
+	struct rtp_event_t event;
+	event.on_rtcp = OnRTCPEvent;
+	m_rtp = rtp_create(&event, this, ssrc, m_timestamp, 90000, 4*1024, 1);
+	rtp_set_info(m_rtp, "RTSPServer", "szj.h265");
+}
+
+H265FileSource::~H265FileSource()
+{
+	if(m_rtp)
+		rtp_destroy(m_rtp);
+
+	if(m_rtppacker)
+		rtp_payload_encode_destroy(m_rtppacker);
+}
+
+int H265FileSource::SetTransport(const char* /*track*/, std::shared_ptr<IRTPTransport> transport)
+{
+	m_transport = transport;
+	return 0;
+}
+
+int H265FileSource::Play()
+{
+	m_status = 1;
+
+	//uint32_t timestamp = 0;
+	time64_t clock = time64_now();
+	if (0 == m_rtp_clock)
+		m_rtp_clock = clock;
+
+	if(m_rtp_clock + 40 < clock)
+	{
+		size_t bytes;
+		const uint8_t* ptr;
+		if(0 == m_reader.GetNextFrame(m_pos, ptr, bytes))
+		{
+			// for(int i=0;i<bytes;i++)
+			// 	printf("%02x ",ptr[i]);
+			// printf("nalu over\n\n\n");
+			rtp_payload_encode_input(m_rtppacker, ptr, bytes, m_timestamp * 90 /*kHz*/);
+			m_rtp_clock += 40;
+			m_timestamp += 40;
+
+			SendRTCP();
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+int H265FileSource::Pause()
+{
+	m_status = 2;
+	m_rtp_clock = 0;
+	return 0;
+}
+
+int H265FileSource::Seek(int64_t pos)
+{
+	m_pos = pos;
+	m_rtp_clock = 0;
+	return m_reader.Seek(m_pos);
+}
+
+int H265FileSource::SetSpeed(double speed)
+{
+	m_speed = speed;
+	return 0;
+}
+
+int H265FileSource::GetDuration(int64_t& duration) const
+{
+	return m_reader.GetDuration(duration);
+}
+
+int H265FileSource::GetSDPMedia(std::string& sdp) const
+{
+    static const char* pattern =
+        "m=video 0 RTP/AVP %d\n"
+        "a=rtpmap:%d H265/90000\n"
+        "a=fmtp:%d profile-level-id=%02X%02X%02X;"
+    			 "packetization-mode=1;"
+    			 "sprop-parameter-sets=";
+
+    char base64[512] = {0};
+    std::string parameters;
+
+    const std::list<std::pair<const uint8_t*, size_t> >& sps = m_reader.GetParameterSets();
+    std::list<std::pair<const uint8_t*, size_t> >::const_iterator it;
+    for(it = sps.begin(); it != sps.end(); ++it)
+    {
+        if(parameters.empty())
+        {
+            snprintf(base64, sizeof(base64), pattern, 
+				RTP_PAYLOAD_H265, RTP_PAYLOAD_H265,RTP_PAYLOAD_H265, 
+				(unsigned int)(it->first[1]), (unsigned int)(it->first[2]), (unsigned int)(it->first[3]));
+            sdp = base64;
+        }
+        else
+        {
+            parameters += ',';
+        }
+
+        size_t bytes = it->second;
+        assert((bytes+2)/3*4 + bytes/57 + 1 < sizeof(base64));
+        bytes = base64_encode(base64, it->first, bytes);
+		base64[bytes] = '\0';
+        assert(strlen(base64) > 0);
+        parameters += base64;
+    }
+
+    sdp += parameters;
+    sdp += '\n';
+    return sps.empty() ? -1 : 0;
+}
+
+int H265FileSource::GetRTPInfo(const char* uri, char *rtpinfo, size_t bytes) const
+{
+	uint16_t seq;
+	uint32_t timestamp;
+	rtp_payload_encode_getinfo(m_rtppacker, &seq, &timestamp);
+
+	// url=rtsp://video.example.com/twister/video;seq=12312232;rtptime=78712811
+	snprintf(rtpinfo, bytes, "url=%s;seq=%hu;rtptime=%u", uri, seq, timestamp);
+	return 0;
+}
+
+void H265FileSource::OnRTCPEvent(const struct rtcp_msg_t* msg)
+{
+	msg;
+}
+
+void H265FileSource::OnRTCPEvent(void* param, const struct rtcp_msg_t* msg)
+{
+	H265FileSource *self = (H265FileSource *)param;
+	self->OnRTCPEvent(msg);
+}
+
+int H265FileSource::SendRTCP()
+{
+	// make sure have sent RTP packet
+
+	time64_t clock = time64_now();
+	int interval = rtp_rtcp_interval(m_rtp);
+	if(0 == m_rtcp_clock || m_rtcp_clock + interval < clock)
+	{
+		char rtcp[1024] = {0};
+		size_t n = rtp_rtcp_report(m_rtp, rtcp, sizeof(rtcp));
+
+		// send RTCP packet
+		m_transport->Send(true, rtcp, n);
+
+		m_rtcp_clock = clock;
+	}
+	
+	return 0;
+}
+
+void* H265FileSource::RTPAlloc(void* param, int bytes)
+{
+	H265FileSource *self = (H265FileSource*)param;
+	assert(bytes <= sizeof(self->m_packet));
+	return self->m_packet;
+}
+
+void H265FileSource::RTPFree(void* param, void *packet)
+{
+	H265FileSource *self = (H265FileSource*)param;
+	assert(self->m_packet == packet);
+}
+
+static int i = 0;
+int H265FileSource::RTPPacket(void* param, const void *packet, int bytes, uint32_t /*timestamp*/, int /*flags*/)
+{
+	H265FileSource *self = (H265FileSource*)param;
+	assert(self->m_packet == packet);
+	const char* ptr = (const char*)packet;
+	// for(int i=0;i<bytes;i++)
+	// 	printf("%02x ",ptr[i]);
+	// printf("RTPPacket over\n\n\n");
+	// if(i++ > 4){
+	// 	exit(-1);
+	// }
+	int r = self->m_transport->Send(false, packet, bytes);
+	if (r != bytes)
+		return -1;
+
+	return rtp_onsend(self->m_rtp, packet, bytes/*, time*/);
+}

--- a/librtsp/test/media/h265-file-source.h
+++ b/librtsp/test/media/h265-file-source.h
@@ -1,0 +1,52 @@
+#ifndef _h265_file_source_h_
+#define _h265_file_source_h_
+
+#include "h265-file-reader.h"
+#include "media-source.h"
+#include "sys/process.h"
+#include "time64.h"
+#include "rtp.h"
+#include <string>
+
+class H265FileSource : public IMediaSource
+{
+public:
+	H265FileSource(const char *file);
+	virtual ~H265FileSource();
+
+public:
+	virtual int Play();
+	virtual int Pause();
+	virtual int Seek(int64_t pos);
+	virtual int SetSpeed(double speed);
+	virtual int GetDuration(int64_t& duration) const;
+	virtual int GetSDPMedia(std::string& sdp) const;
+	virtual int GetRTPInfo(const char* uri, char *rtpinfo, size_t bytes) const;
+	virtual int SetTransport(const char* track, std::shared_ptr<IRTPTransport> transport);
+
+private:
+	static void OnRTCPEvent(void* param, const struct rtcp_msg_t* msg);
+	void OnRTCPEvent(const struct rtcp_msg_t* msg);
+	int SendRTCP();
+
+	static void* RTPAlloc(void* param, int bytes);
+	static void RTPFree(void* param, void *packet);
+	static int RTPPacket(void* param, const void *packet, int bytes, uint32_t timestamp, int flags);
+
+private:
+	void* m_rtp;
+	uint32_t m_timestamp;
+	time64_t m_rtp_clock;
+	time64_t m_rtcp_clock;
+    H265FileReader m_reader;
+	std::shared_ptr<IRTPTransport> m_transport;
+
+	int m_status;
+	int64_t m_pos;
+	double m_speed;
+
+	void *m_rtppacker;
+	unsigned char m_packet[MAX_UDP_PACKET+14];
+};
+
+#endif /* !_h265_file_source_h_ */

--- a/librtsp/test/rtsp-server-test.cpp
+++ b/librtsp/test/rtsp-server-test.cpp
@@ -11,6 +11,7 @@
 #include "rtsp-server.h"
 #include "media/ps-file-source.h"
 #include "media/h264-file-source.h"
+#include "media/h265-file-source.h"
 #include "media/mp4-file-source.h"
 #include "rtp-udp-transport.h"
 #include "rtp-tcp-transport.h"
@@ -129,6 +130,8 @@ static int rtsp_ondescribe(void* /*ptr*/, rtsp_server_t* rtsp, const char* uri)
 					source.reset(new PSFileSource(filename.c_str()));
 				else if (strendswith(filename.c_str(), ".h264"))
 					source.reset(new H264FileSource(filename.c_str()));
+				else if (strendswith(filename.c_str(), ".h265"))
+					source.reset(new H265FileSource(filename.c_str()));					
 				else
 				{
 #if defined(_HAVE_FFMPEG_)
@@ -221,6 +224,8 @@ static int rtsp_onsetup(void* /*ptr*/, rtsp_server_t* rtsp, const char* uri, con
 				item.media.reset(new PSFileSource(filename.c_str()));
 			else if (strendswith(filename.c_str(), ".h264"))
 				item.media.reset(new H264FileSource(filename.c_str()));
+			else if (strendswith(filename.c_str(), ".h265"))
+				item.media.reset(new H265FileSource(filename.c_str()));				
 			else
 			{
 #if defined(_HAVE_FFMPEG_)

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -163,6 +163,8 @@
     <ClInclude Include="..\librtsp\test\media\avpacket-queue.h" />
     <ClInclude Include="..\librtsp\test\media\ffmpeg-file-source.h" />
     <ClInclude Include="..\librtsp\test\media\ffmpeg-live-source.h" />
+    <ClInclude Include="..\librtsp\test\media\h265-file-reader.h" />
+    <ClInclude Include="..\librtsp\test\media\h265-file-source.h" />
     <ClInclude Include="..\librtsp\test\media\mp4-file-reader.h" />
     <ClInclude Include="..\librtsp\test\media\vod-file-source.h" />
     <ClInclude Include="..\librtsp\test\media\h264-file-reader.h" />
@@ -271,6 +273,8 @@
     <ClCompile Include="..\librtsp\test\media\ffmpeg-live-source.cpp" />
     <ClCompile Include="..\librtsp\test\media\h264-file-reader.cpp" />
     <ClCompile Include="..\librtsp\test\media\h264-file-source.cpp" />
+    <ClCompile Include="..\librtsp\test\media\h265-file-reader.cpp" />
+    <ClCompile Include="..\librtsp\test\media\h265-file-source.cpp" />
     <ClCompile Include="..\librtsp\test\media\mp4-file-reader.cpp" />
     <ClCompile Include="..\librtsp\test\media\mp4-file-source.cpp" />
     <ClCompile Include="..\librtsp\test\media\pcm-file-source.cpp" />


### PR DESCRIPTION
1、这次提交增加了简易的 h265 文件 reader和source 。 这样rtsp_server可以直接支持265文件。 已在win和linux上测试过。
2、可以使用H265FileSource 稍微修改下用例即可以 ps-rtp，rtsp-client-push支持推h265文件。
 