### PR TITLE
Add MOV_TAG for MOV_OBJECT_JPEG

### DIFF
--- a/libmov/source/mov-tag.c
+++ b/libmov/source/mov-tag.c
@@ -32,6 +32,7 @@ static struct mov_object_tag s_tags[] = {
     { MOV_OBJECT_DTS,   MOV_DTS },
     { MOV_OBJECT_VC1,   MOV_VC1 },
     { MOV_OBJECT_DIRAC, MOV_DIRAC },
+    { MOV_OBJECT_JPEG,  MOV_TAG('j', 'p', 'e', 'g') },
 };
 
 uint32_t mov_object_to_tag(uint8_t object)


### PR DESCRIPTION
Hello, please consider this change.
This is needed for [pull](https://github.com/ZLMediaKit/ZLMediaKit/pull/2183)