### PR TITLE
[what][draft][mov] 引入 mov_block_t 将部分内存管理控制权转给到调用方

### DIFF
--- a/libmov/include/mov-blocks.h
+++ b/libmov/include/mov-blocks.h
@@ -1,0 +1,35 @@
+#ifndef _mov_blocks_h_
+#define _mov_blocks_h_
+
+#include <stdint.h>
+
+struct mov_blocks_t
+{
+	/// create a blocks
+    /// @param[in] param       user-defined parameter
+    /// @param[in] id          blocks identifier
+    /// @param[in] block_size  single block size
+    /// @return 0-ok, <0-error
+	int  (*create)(void* param, uint32_t id, uint32_t block_size);
+
+	/// destroy a blocks
+    /// @param[in]  param user-defined parameter
+    /// @param[in]  id    blocks identifier
+    /// @return 0-ok, <0-error
+	int  (*destroy)(void* param, uint32_t id);
+
+	/// set blocks capacity
+    /// @param[in]  param     user-defined parameter
+    /// @param[in]  id        blocks identifier
+    /// @param[in]  capacity  blocks capacity
+	int  (*set_capacity)(void* param, uint32_t id, uint64_t capacity);
+
+	/// get block by index
+    /// @param[in]  param   user-defined parameter
+    /// @param[in]  id      blocks identifier
+    /// @param[in]  index   block index in blocks
+    /// @return     memory pointer
+	void* (*at)(void* param, uint32_t id, uint64_t index);
+};
+
+#endif /*! _mov_blocks_h_ */

--- a/libmov/include/mov-writer.h
+++ b/libmov/include/mov-writer.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "mov-buffer.h"
+#include "mov-blocks.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,7 +13,7 @@ extern "C" {
 typedef struct mov_writer_t mov_writer_t;
 
 /// @param[in] flags mov flags, such as: MOV_FLAG_FASTSTART, see more @mov-format.h
-mov_writer_t* mov_writer_create(const struct mov_buffer_t* buffer, void* param, int flags);
+mov_writer_t* mov_writer_create(const struct mov_buffer_t* buffer, const struct mov_blocks_t* blocks, void* buffer_param, void* blocks_param, int flags);
 void mov_writer_destroy(mov_writer_t* mov);
 
 /// @param[in] object MPEG-4 systems ObjectTypeIndication such as: MOV_OBJECT_H264, see more @mov-format.h

--- a/libmov/source/fmp4-reader.c
+++ b/libmov/source/fmp4-reader.c
@@ -8,13 +8,14 @@ static int mov_fragment_seek_get_duration(struct mov_t* mov)
 {
 	int i;
 	struct mov_track_t* track;
-	track = mov->track_count > 0 ? &mov->tracks[0] : NULL;
+	uint32_t track_id = 0;
+	track = mov->track_count > 0 ? &mov->tracks[track_id] : NULL;
 	if (track && track->frag_capacity < track->frag_count && track->mdhd.timescale)
 	{
 		mov_buffer_seek(&mov->io, track->frags[track->frag_count - 1].offset);
 		mov_reader_root(mov); // moof
 
-		track->mdhd.duration = track->samples[track->sample_count - 1].dts - track->samples[0].dts;
+		track->mdhd.duration = mov_sample_t_at(&mov->blocks, track_id, track->sample_count - 1)->dts - mov_sample_t_at(&mov->blocks, track_id, 0)->dts;
 		mov->mvhd.duration = track->mdhd.duration * mov->mvhd.timescale / track->mdhd.timescale;
 		
 		// clear samples and seek to the first moof

--- a/libmov/source/fmp4-writer.c
+++ b/libmov/source/fmp4-writer.c
@@ -78,8 +78,10 @@ static size_t fmp4_write_traf(struct mov_t* mov, uint32_t moof)
     if (track->sample_count > 0)
     {
         track->tfhd.flags |= MOV_TFHD_FLAG_DEFAULT_DURATION | MOV_TFHD_FLAG_DEFAULT_SIZE;
-        track->tfhd.default_sample_duration = track->sample_count > 1 ? (uint32_t)(track->samples[1].dts - track->samples[0].dts) : (uint32_t)track->turn_last_duration;
-        track->tfhd.default_sample_size = track->samples[0].bytes;
+        track->tfhd.default_sample_duration = track->sample_count > 1 ? 
+			(uint32_t)(mov_sample_t_at(&mov->blocks, track->track_id, 1)->dts - mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts) : 
+			(uint32_t)track->turn_last_duration;
+        track->tfhd.default_sample_size = mov_sample_t_at(&mov->blocks, track->track_id, 0)->bytes;
     }
     else
     {
@@ -95,7 +97,8 @@ static size_t fmp4_write_traf(struct mov_t* mov, uint32_t moof)
 
 	for (start = 0, i = 1; i < track->sample_count; i++)
 	{
-        if (track->samples[i - 1].offset + track->samples[i - 1].bytes != track->samples[i].offset)
+        if (mov_sample_t_at(&mov->blocks, track->track_id, i - 1)->offset + mov_sample_t_at(&mov->blocks, track->track_id, i - 1)->bytes 
+			!= mov_sample_t_at(&mov->blocks, track->track_id, i)->offset)
         {
             size += mov_write_trun(mov, start, i-start, moof);
             start = i;
@@ -130,8 +133,8 @@ static size_t fmp4_write_moof(struct mov_t* mov, uint32_t fragment, uint32_t moo
 		// 2017/10/17 Dale Curtis SHA-1: a5fd8aa45b11c10613e6e576033a6b5a16b9cbb9 (libavformat/mov.c)
 		for (j = 0; j < mov->track->sample_count; j++)
 		{
-			mov->track->samples[j].offset = n;
-			n += mov->track->samples[j].bytes;
+			mov_sample_t_at(&mov->blocks, mov->track->track_id, j)->offset = n;
+			n += mov_sample_t_at(&mov->blocks, mov->track->track_id, j)->bytes;
 		}
 
 		if (mov->track->sample_count > 0)
@@ -272,7 +275,7 @@ static int fmp4_write_fragment(struct fmp4_writer_t* writer)
 	{
 		mov->track = mov->tracks + i;
 		if (mov->track->sample_count > 0 && 0 == (mov->flags & MOV_FLAG_SEGMENT))
-			fmp4_add_fragment_entry(mov->track, mov->track->samples[0].dts, mov->moof_offset);
+			fmp4_add_fragment_entry(mov->track, mov_sample_t_at(&mov->blocks, mov->track->track_id, 0)->dts, mov->moof_offset);
 
 		// hack: write sidx referenced_size
 		if (mov->flags & MOV_FLAG_SEGMENT)
@@ -301,11 +304,13 @@ static int fmp4_write_fragment(struct fmp4_writer_t* writer)
 		for (i = 0; i < mov->track_count; i++)
 		{
 			mov->track = mov->tracks + i;
-			while (mov->track->offset < mov->track->sample_count && n == mov->track->samples[mov->track->offset].offset)
+			while (mov->track->offset < mov->track->sample_count && n == mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->offset)->offset)
             {
-                mov_buffer_write(&mov->io, mov->track->samples[mov->track->offset].data, mov->track->samples[mov->track->offset].bytes);
-                free(mov->track->samples[mov->track->offset].data); // free av packet memory
-                n += mov->track->samples[mov->track->offset].bytes;
+				
+                mov_buffer_write(&mov->io, mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->offset)->data,
+					 mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->offset)->bytes);
+                free(mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->offset)->data); // free av packet memory
+                n += mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->offset)->bytes;
                 ++mov->track->offset;
             }
 		}
@@ -354,6 +359,8 @@ static int fmp4_writer_init(struct mov_t* mov)
 
 struct fmp4_writer_t* fmp4_writer_create(const struct mov_buffer_t *buffer, void* param, int flags)
 {
+	// todo : adaptor mov_blocks_t
+
 	struct mov_t* mov;
 	struct fmp4_writer_t* writer;
 	writer = (struct fmp4_writer_t*)calloc(1, sizeof(struct fmp4_writer_t));
@@ -385,7 +392,7 @@ void fmp4_writer_destroy(struct fmp4_writer_t* writer)
 	fmp4_writer_save_segment(writer);
 
 	for (i = 0; i < mov->track_count; i++)
-        mov_free_track(mov->tracks + i);
+        mov_free_track(mov, mov->tracks + i);
 	if (mov->tracks)
 		free(mov->tracks);
 	free(writer);
@@ -416,16 +423,17 @@ int fmp4_writer_write(struct fmp4_writer_t* writer, int idx, const void* data, s
 
 	if (track->sample_count + 1 >= track->sample_offset)
 	{
-		void* ptr = realloc(track->samples, sizeof(struct mov_sample_t) * (track->sample_offset + 1024));
-		if (NULL == ptr) return -ENOMEM;
-		track->samples = (struct mov_sample_t*)ptr;
+		if (mov_blocks_set_capacity(&writer->mov.blocks, idx, track->sample_offset + 1024) < 0)
+		{
+			return -ENOMEM;
+		}
 		track->sample_offset += 1024;
 	}
 
 	pts = pts * track->mdhd.timescale / 1000;
 	dts = dts * track->mdhd.timescale / 1000;
 
-	sample = &track->samples[track->sample_count];
+	sample = mov_sample_t_at(&writer->mov.blocks, idx, track->sample_count);
 	sample->sample_description_index = 1;
 	sample->bytes = (uint32_t)bytes;
 	sample->flags = flags;

--- a/libmov/source/mov-blocks-util.h
+++ b/libmov/source/mov-blocks-util.h
@@ -1,0 +1,39 @@
+#ifndef _mov_blocks_ulti_h_
+#define _mov_ioutil_ulti_h_
+
+#include "mov-blocks.h"
+
+struct mov_sample_t;
+
+struct mov_blocks_utli_t
+{
+    struct mov_blocks_t blocks;
+    void* param;
+};
+
+static inline int mov_blocks_create(const struct mov_blocks_utli_t* blocks, uint32_t id, uint32_t block_size)
+{
+    return blocks->blocks.create(blocks->param, id, block_size); 
+};
+
+static inline int mov_blocks_destroy(const struct mov_blocks_utli_t* blocks, uint32_t id)
+{
+    return blocks->blocks.destroy(blocks->param, id);
+}
+
+static inline int mov_blocks_set_capacity(const struct mov_blocks_utli_t* blocks, uint32_t id, uint64_t capacity)
+{
+    return blocks->blocks.set_capacity(blocks->param, id, capacity);
+}
+
+static inline void* mov_blocks_at(const struct mov_blocks_utli_t* blocks, uint32_t id, uint64_t index)
+{
+    return blocks->blocks.at(blocks->param, id, index);
+}
+
+static inline struct mov_sample_t* mov_sample_t_at(const struct mov_blocks_utli_t* blocks, uint32_t id, uint64_t index)
+{
+    return (struct mov_sample_t*)mov_blocks_at(blocks, id, index);
+}
+
+#endif /* !_mov_ioutil_ulti_h_ */

--- a/libmov/source/mov-elst.c
+++ b/libmov/source/mov-elst.c
@@ -52,13 +52,13 @@ size_t mov_write_elst(const struct mov_t* mov)
 	uint8_t version;
 	const struct mov_track_t* track = mov->track;
 
-    assert(track->start_dts == track->samples[0].dts);
+    assert(track->start_dts == mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts);
 	version = track->tkhd.duration > UINT32_MAX ? 1 : 0;
 
     // in media time scale units, in composition time
-	time = track->samples[0].pts - track->samples[0].dts;
+	time = mov_sample_t_at(&mov->blocks, track->track_id, 0)->pts - mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts;
     // in units of the timescale in the Movie Header Box
-	delay = track->samples[0].pts * mov->mvhd.timescale / track->mdhd.timescale;
+	delay = mov_sample_t_at(&mov->blocks, track->track_id, 0)->pts * mov->mvhd.timescale / track->mdhd.timescale;
 	if (delay > UINT32_MAX)
 		version = 1;
 
@@ -105,24 +105,24 @@ size_t mov_write_elst(const struct mov_t* mov)
 	return size;
 }
 
-void mov_apply_elst(struct mov_track_t *track)
+void mov_apply_elst(const struct mov_t* mov, struct mov_track_t *track)
 {
     size_t i;
 
     // edit list
-    track->samples[0].dts = 0;
-    track->samples[0].pts = 0;
+    mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts = 0;
+    mov_sample_t_at(&mov->blocks, track->track_id, 0)->pts = 0;
     for (i = 0; i < track->elst_count; i++)
     {
         if (-1 == track->elst[i].media_time)
         {
-            track->samples[0].dts = track->elst[i].segment_duration;
-            track->samples[0].pts = track->samples[0].dts;
+            mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts = track->elst[i].segment_duration;
+            mov_sample_t_at(&mov->blocks, track->track_id, 0)->pts = mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts;
         }
     }
 }
 
-void mov_apply_elst_tfdt(struct mov_track_t *track)
+void mov_apply_elst_tfdt(const struct mov_t* mov, struct mov_track_t *track)
 {
     size_t i;
 

--- a/libmov/source/mov-internal.h
+++ b/libmov/source/mov-internal.h
@@ -6,6 +6,7 @@
 #include "mov-format.h"
 #include "mov-buffer.h"
 #include "mov-ioutil.h"
+#include "mov-blocks-util.h"
 
 #define MOV_APP "ireader/media-server"
 
@@ -163,6 +164,8 @@ struct mov_track_t
 	uint32_t handler_type; // MOV_VIDEO/MOV_AUDIO
 	const char* handler_descr; // VideoHandler/SoundHandler/SubtitleHandler
 
+	uint32_t track_id; // todo : correctly assign track id when track change
+
 	struct mov_tkhd_t tkhd;
 	struct mov_mdhd_t mdhd;
 	struct mov_stbl_t stbl;
@@ -178,7 +181,7 @@ struct mov_track_t
 	struct mov_elst_t* elst;
 	size_t elst_count;
 	
-	struct mov_sample_t* samples;
+	struct mov_sample_t* samples; // todo : remove it use mov_blocks_utli_t instead
 	uint32_t sample_count;
 	size_t sample_offset; // sample_capacity
 
@@ -193,7 +196,8 @@ struct mov_track_t
 
 struct mov_t
 {
-	struct mov_ioutil_t io;
+	struct mov_ioutil_t       io;
+	struct mov_blocks_utli_t  blocks;
 	
 	struct mov_ftyp_t ftyp;
 	struct mov_mvhd_t mvhd;
@@ -300,19 +304,19 @@ size_t mov_write_trak(const struct mov_t* mov);
 size_t mov_write_dops(const struct mov_t* mov);
 size_t mov_write_udta(const struct mov_t* mov);
 
-uint32_t mov_build_stts(struct mov_track_t* track);
-uint32_t mov_build_ctts(struct mov_track_t* track);
-uint32_t mov_build_stco(struct mov_track_t* track);
-void mov_apply_stco(struct mov_track_t* track);
-void mov_apply_elst(struct mov_track_t *track);
-void mov_apply_stts(struct mov_track_t* track);
-void mov_apply_ctts(struct mov_track_t* track);
-void mov_apply_stss(struct mov_track_t* track);
-void mov_apply_elst_tfdt(struct mov_track_t *track);
+uint32_t mov_build_stts(const struct mov_t* mov, struct mov_track_t* track);
+uint32_t mov_build_ctts(const struct mov_t* mov, struct mov_track_t* track);
+uint32_t mov_build_stco(const struct mov_t* mov, struct mov_track_t* track);
+void mov_apply_stco(const struct mov_t* mov, struct mov_track_t* track);
+void mov_apply_elst(const struct mov_t* mov, struct mov_track_t *track);
+void mov_apply_stts(const struct mov_t* mov, struct mov_track_t* track);
+void mov_apply_ctts(const struct mov_t* mov, struct mov_track_t* track);
+void mov_apply_stss(const struct mov_t* mov, struct mov_track_t* track);
+void mov_apply_elst_tfdt(const struct mov_t* mov, struct mov_track_t *track);
 
 void mov_write_size(const struct mov_t* mov, uint64_t offset, size_t size);
 
-size_t mov_stco_size(const struct mov_track_t* track, uint64_t offset);
+size_t mov_stco_size(const struct mov_t* mov, const struct mov_track_t* track, uint64_t offset);
 
 int mov_fragment_read_next_moof(struct mov_t* mov);
 int mov_fragment_seek_read_mfra(struct mov_t* mov);
@@ -321,7 +325,7 @@ int mov_fragment_seek(struct mov_t* mov, int64_t* timestamp);
 uint8_t mov_tag_to_object(uint32_t tag);
 uint32_t mov_object_to_tag(uint8_t object);
 
-void mov_free_track(struct mov_track_t* track);
+void mov_free_track(const struct mov_t* mov, struct mov_track_t* track);
 struct mov_track_t* mov_add_track(struct mov_t* mov);
 struct mov_track_t* mov_find_track(const struct mov_t* mov, uint32_t track);
 struct mov_track_t* mov_fetch_track(struct mov_t* mov, uint32_t track); // find and add

--- a/libmov/source/mov-reader.c
+++ b/libmov/source/mov-reader.c
@@ -33,8 +33,8 @@ struct mov_parse_t
 	int(*parse)(struct mov_t* mov, const struct mov_box_t* box);
 };
 
-static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp);
-static int mov_sample_seek(struct mov_track_t* track, int64_t timestamp);
+static int mov_stss_seek(struct mov_t* mov, struct mov_track_t* track, int64_t *timestamp);
+static int mov_sample_seek(struct mov_t* mov, struct mov_track_t* track, int64_t timestamp);
 
 // 8.1.1 Media Data Box (p28)
 static int mov_read_mdat(struct mov_t* mov, const struct mov_box_t* box)
@@ -58,7 +58,7 @@ static int mov_read_free(struct mov_t* mov, const struct mov_box_t* box)
 //    return NULL;
 //}
 
-static int mov_index_build(struct mov_track_t* track)
+static int mov_index_build(struct mov_t* mov, struct mov_track_t* track)
 {
 	void* p;
 	uint32_t i, j;
@@ -69,7 +69,7 @@ static int mov_index_build(struct mov_track_t* track)
 
 	for (i = 0; i < track->sample_count; i++)
 	{
-		if (track->samples[i].flags & MOV_AV_FLAG_KEYFREAME)
+		if (mov_sample_t_at(&mov->blocks, track->track_id, i)->flags & MOV_AV_FLAG_KEYFREAME)
 			++stbl->stss_count;
 	}
 
@@ -79,7 +79,7 @@ static int mov_index_build(struct mov_track_t* track)
 
 	for (j = i = 0; i < track->sample_count && j < stbl->stss_count; i++)
 	{
-		if (track->samples[i].flags & MOV_AV_FLAG_KEYFREAME)
+		if (mov_sample_t_at(&mov->blocks, track->track_id, i)->flags & MOV_AV_FLAG_KEYFREAME)
 			stbl->stss[j++] = i + 1; // uint32_t sample_number, start from 1
 	}
 	assert(j == stbl->stss_count);
@@ -102,13 +102,13 @@ static int mov_read_trak(struct mov_t* mov, const struct mov_box_t* box)
         mov->track->tfdt_dts = 0;
         if (mov->track->sample_count > 0)
         {
-            mov_apply_stco(mov->track);
-            mov_apply_elst(mov->track);
-            mov_apply_stts(mov->track);
-            mov_apply_ctts(mov->track);
-			mov_apply_stss(mov->track);
-
-            mov->track->tfdt_dts = mov->track->samples[mov->track->sample_count - 1].dts;
+            mov_apply_stco(mov, mov->track);
+            mov_apply_elst(mov, mov->track);
+            mov_apply_stts(mov, mov->track);
+            mov_apply_ctts(mov, mov->track);
+			mov_apply_stss(mov, mov->track);
+			
+            mov->track->tfdt_dts = mov_sample_t_at(&mov->blocks, mov->track->track_id, mov->track->sample_count - 1)->dts;
         }
 	}
 
@@ -375,12 +375,12 @@ static int mov_reader_init(struct mov_reader_t* reader)
 	for (i = 0; i < mov->track_count; i++)
 	{
 		track = mov->tracks + i;
-		mov_index_build(track);
+		mov_index_build(mov, track);
 		//track->sample_offset = 0; // reset
 		
 		// fragment mp4
 		if (0 == track->mdhd.duration && track->sample_count > 0)
-			track->mdhd.duration = track->samples[track->sample_count - 1].dts - track->samples[0].dts;
+			track->mdhd.duration = mov_sample_t_at(&mov->blocks, track->track_id, track->sample_count - 1)->dts - mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts;
 		if (0 == track->tkhd.duration)
 			track->tkhd.duration = track->mdhd.duration * mov->mvhd.timescale / track->mdhd.timescale;
 		if (track->tkhd.duration > mov->mvhd.duration)
@@ -423,7 +423,7 @@ void mov_reader_destroy(struct mov_reader_t* reader)
 {
 	int i;
 	for (i = 0; i < reader->mov.track_count; i++)
-		mov_free_track(reader->mov.tracks + i);
+		mov_free_track(&reader->mov, reader->mov.tracks + i);
 	if (reader->mov.tracks)
 		free(reader->mov.tracks);
 	free(reader);
@@ -435,6 +435,7 @@ static struct mov_track_t* mov_reader_next(struct mov_reader_t* reader)
 	int64_t dts, best_dts = 0;
 	struct mov_track_t* track = NULL;
 	struct mov_track_t* track2;
+	struct mov_t*       mov = &reader->mov;
 
 	for (i = 0; i < reader->mov.track_count; i++)
 	{
@@ -443,10 +444,10 @@ static struct mov_track_t* mov_reader_next(struct mov_reader_t* reader)
 		if (track2->sample_offset >= track2->sample_count)
 			continue;
 
-		dts = track2->samples[track2->sample_offset].dts * 1000 / track2->mdhd.timescale;
+		dts = mov_sample_t_at(&mov->blocks, track2->track_id, track2->sample_offset)->dts * 1000 / track2->mdhd.timescale;
 		//if (NULL == track || dts < best_dts)
-		//if (NULL == track || track->samples[track->sample_offset].offset > track2->samples[track2->sample_offset].offset)
-		if (NULL == track || (dts < best_dts && best_dts - dts > AV_TRACK_TIMEBASE) || track2->samples[track2->sample_offset].offset < track->samples[track->sample_offset].offset)
+		//if (NULL == track || mov_sample_t_at(&mov->blocks, track->track_id, track->sample_offset)->offset > mov_sample_t_at(&mov->blocks, track2->track_id, track2->sample_offset)->offset)
+		if (NULL == track || (dts < best_dts && best_dts - dts > AV_TRACK_TIMEBASE) || mov_sample_t_at(&mov->blocks, track2->track_id, track2->sample_offset)->offset < mov_sample_t_at(&mov->blocks, track->track_id, track->sample_offset)->offset)
 		{
 			track = track2;
 			best_dts = dts;
@@ -461,6 +462,7 @@ int mov_reader_read2(struct mov_reader_t* reader, mov_reader_onread2 onread, voi
 	void* ptr;
 	struct mov_track_t* track;
 	struct mov_sample_t* sample;
+	struct mov_t* mov = &reader->mov;
 
 FMP4_NEXT_FRAGMENT:
 	track = mov_reader_next(reader);
@@ -475,7 +477,7 @@ FMP4_NEXT_FRAGMENT:
 	}
 
 	assert(track->sample_offset < track->sample_count);
-	sample = &track->samples[track->sample_offset];
+	sample = mov_sample_t_at(&mov->blocks, track->track_id, track->sample_offset);
 	assert(sample->sample_description_index > 0);
 	ptr = onread(param, track->tkhd.track_ID, /*sample->sample_description_index-1,*/ sample->bytes, sample->pts * 1000 / track->mdhd.timescale, sample->dts * 1000 / track->mdhd.timescale, sample->flags);
 	if(!ptr)
@@ -538,7 +540,7 @@ int mov_reader_seek(struct mov_reader_t* reader, int64_t* timestamp)
 		track = &reader->mov.tracks[i];
 		if (MOV_VIDEO == track->handler_type && track->stbl.stss_count > 0)
 		{
-			if (0 != mov_stss_seek(track, timestamp))
+			if (0 != mov_stss_seek(&reader->mov, track, timestamp))
 				return -1;
 		}
 	}
@@ -550,7 +552,7 @@ int mov_reader_seek(struct mov_reader_t* reader, int64_t* timestamp)
 		if (MOV_VIDEO == track->handler_type && track->stbl.stss_count > 0)
 			continue; // seek done
 
-		mov_sample_seek(track, *timestamp);
+		mov_sample_seek(&reader->mov, track, *timestamp);
 	}
 
 	return 0;
@@ -600,7 +602,7 @@ uint64_t mov_reader_getduration(struct mov_reader_t* reader)
 
 #define DIFF(a, b) ((a) > (b) ? ((a) - (b)) : ((b) - (a)))
 
-static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp)
+static int mov_stss_seek(struct mov_t* mov, struct mov_track_t* track, int64_t *timestamp)
 {
 	int64_t clock;
 	size_t start, end, mid;
@@ -624,7 +626,7 @@ static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp)
 			return -1;
 		}
 		idx -= 1;
-		sample = &track->samples[idx];
+		sample = mov_sample_t_at(&mov->blocks, track->track_id, idx);
 		
 		if (sample->dts > clock)
 			end = mid;
@@ -636,17 +638,17 @@ static int mov_stss_seek(struct mov_track_t* track, int64_t *timestamp)
 
 	prev = track->stbl.stss[mid > 0 ? mid - 1 : mid] - 1;
 	next = track->stbl.stss[mid + 1 < track->stbl.stss_count ? mid + 1 : mid] - 1;
-	if (DIFF(track->samples[prev].dts, clock) < DIFF(track->samples[idx].dts, clock))
+	
+	if (DIFF(mov_sample_t_at(&mov->blocks, track->track_id, prev)->dts, clock) < DIFF(mov_sample_t_at(&mov->blocks, track->track_id, idx)->dts, clock))
 		idx = prev;
-	if (DIFF(track->samples[next].dts, clock) < DIFF(track->samples[idx].dts, clock))
+	if (DIFF(mov_sample_t_at(&mov->blocks, track->track_id, next)->dts, clock) < DIFF(mov_sample_t_at(&mov->blocks, track->track_id, idx)->dts, clock))
 		idx = next;
-
-	*timestamp = track->samples[idx].dts * 1000 / track->mdhd.timescale;
+	*timestamp = mov_sample_t_at(&mov->blocks, track->track_id, idx)->dts * 1000 / track->mdhd.timescale;
 	track->sample_offset = idx;
 	return 0;
 }
 
-static int mov_sample_seek(struct mov_track_t* track, int64_t timestamp)
+static int mov_sample_seek(struct mov_t* mov, struct mov_track_t* track, int64_t timestamp)
 {
 	size_t prev, next;
 	size_t start, end, mid;
@@ -663,7 +665,7 @@ static int mov_sample_seek(struct mov_track_t* track, int64_t timestamp)
 	while (start < end)
 	{
 		mid = (start + end) / 2;
-		sample = track->samples + mid;
+		sample = mov_sample_t_at(&mov->blocks, track->track_id, mid);
 		
 		if (sample->dts > timestamp)
 			end = mid;
@@ -675,9 +677,9 @@ static int mov_sample_seek(struct mov_track_t* track, int64_t timestamp)
 
 	prev = mid > 0 ? mid - 1 : mid;
 	next = mid + 1 < track->sample_count ? mid + 1 : mid;
-	if (DIFF(track->samples[prev].dts, timestamp) < DIFF(track->samples[mid].dts, timestamp))
+	if (DIFF(mov_sample_t_at(&mov->blocks, track->track_id, prev)->dts, timestamp) < DIFF(mov_sample_t_at(&mov->blocks, track->track_id, mid)->dts, timestamp))
 		mid = prev;
-	if (DIFF(track->samples[next].dts, timestamp) < DIFF(track->samples[mid].dts, timestamp))
+	if (DIFF(mov_sample_t_at(&mov->blocks, track->track_id, next)->dts, timestamp) < DIFF(mov_sample_t_at(&mov->blocks, track->track_id, mid)->dts, timestamp))
 		mid = next;
 
 	track->sample_offset = mid;

--- a/libmov/source/mov-sidx.c
+++ b/libmov/source/mov-sidx.c
@@ -44,8 +44,8 @@ size_t mov_write_sidx(const struct mov_t* mov, uint64_t offset)
 
     if (track->sample_count > 0)
     {
-        earliest_presentation_time = track->samples[0].pts;
-        duration = (uint32_t)(track->samples[track->sample_count - 1].dts - track->samples[0].dts) + (uint32_t)track->turn_last_duration;
+        earliest_presentation_time = mov_sample_t_at(&mov->blocks, track->track_id, 0)->pts;
+        duration = (uint32_t)(mov_sample_t_at(&mov->blocks, track->track_id, track->sample_count - 1)->dts - mov_sample_t_at(&mov->blocks, track->track_id, 0)->dts) + (uint32_t)track->turn_last_duration;
     }
     else
     {

--- a/libmov/source/mov-stsc.c
+++ b/libmov/source/mov-stsc.c
@@ -62,7 +62,7 @@ size_t mov_write_stsc(const struct mov_t* mov)
 
 	for (i = 0, entry = 0; i < track->sample_count; i++)
 	{
-		sample = &track->samples[i];
+		sample = mov_sample_t_at(&mov->blocks, track->track_id, i);;
 		if (0 == sample->first_chunk || 
 			(chunk && chunk->samples_per_chunk == sample->samples_per_chunk 
 				&& chunk->sample_description_index == sample->sample_description_index))

--- a/libmov/source/mov-stss.c
+++ b/libmov/source/mov-stss.c
@@ -47,7 +47,7 @@ size_t mov_write_stss(const struct mov_t* mov)
 
 	for (i = 0, j = 0; i < track->sample_count; i++)
 	{
-		sample = &track->samples[i];
+		sample = mov_sample_t_at(&mov->blocks, track->track_id, i);
 		if (sample->flags & MOV_AV_FLAG_KEYFREAME)
 		{
 			++j;
@@ -65,7 +65,7 @@ size_t mov_write_stss(const struct mov_t* mov)
 	return size;
 }
 
-void mov_apply_stss(struct mov_track_t* track)
+void mov_apply_stss(const struct mov_t* mov, struct mov_track_t* track)
 {
 	size_t i, j;
 	struct mov_stbl_t* stbl = &track->stbl;
@@ -74,6 +74,6 @@ void mov_apply_stss(struct mov_track_t* track)
 	{
 		j = stbl->stss[i]; // start from 1
 		if (j > 0 && j <= track->sample_count)
-			track->samples[j - 1].flags |= MOV_AV_FLAG_KEYFREAME;
+			mov_sample_t_at(&mov->blocks, track->track_id, j-1)->flags |= MOV_AV_FLAG_KEYFREAME;
 	}
 }

--- a/libmov/source/mov-tfdt.c
+++ b/libmov/source/mov-tfdt.c
@@ -17,7 +17,7 @@ int mov_read_tfdt(struct mov_t* mov, const struct mov_box_t* box)
         mov->track->tfdt_dts = mov_buffer_r32(&mov->io); /* baseMediaDecodeTime */
 
     // baseMediaDecodeTime + ELST start offset
-    mov_apply_elst_tfdt(mov->track);
+    mov_apply_elst_tfdt(mov, mov->track);
 
 	(void)box;
     return mov_buffer_error(&mov->io);
@@ -31,7 +31,7 @@ size_t mov_write_tfdt(const struct mov_t* mov)
     if (mov->track->sample_count < 1)
         return 0;
 
-    baseMediaDecodeTime = mov->track->samples[0].dts - mov->track->start_dts;
+    baseMediaDecodeTime = mov_sample_t_at(&mov->blocks, mov->track->track_id, 0)->dts - mov->track->start_dts;
     version = baseMediaDecodeTime > INT32_MAX ? 1 : 0;
 
     mov_buffer_w32(&mov->io, 0 == version ? 16 : 20); /* size */

--- a/libmov/test/mov-memory-blocks.cpp
+++ b/libmov/test/mov-memory-blocks.cpp
@@ -1,0 +1,3 @@
+#include "mov-memory-blocks.h"
+
+// todo : implement it with realloc

--- a/libmov/test/mov-memory-blocks.h
+++ b/libmov/test/mov-memory-blocks.h
@@ -1,0 +1,15 @@
+#ifndef _mov_memory_blocks_h_
+#define _mov_memory_blocks_h_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mov-blocks.h"
+
+const struct mov_blocks_t* mov_memory_blocks(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !_mov_memory_blocks_h_ */


### PR DESCRIPTION
https://github.com/ireader/media-server/issues/264

针对于 `mov_sample_t` 结构体积累导致的内存增长, 有一个特点即为单个 `mov_sample_t` 所占用的内存空间是固定的;所以我想一下,可能使用 `std::vector` 这种方式暴露内存分配的方式比 `new` 的方式合适一点;所以定义了 `mov_blocks_t` : 
```cpp
struct mov_blocks_t
{
	/// create a blocks
    /// @param[in] param       user-defined parameter
    /// @param[in] id          blocks identifier
    /// @param[in] block_size  single block size
    /// @return 0-ok, <0-error
	int  (*create)(void* param, uint32_t id, uint32_t block_size);

	/// destroy a blocks
    /// @param[in]  param user-defined parameter
    /// @param[in]  id    blocks identifier
    /// @return 0-ok, <0-error
	int  (*destroy)(void* param, uint32_t id);

	/// set blocks capacity
    /// @param[in]  param     user-defined parameter
    /// @param[in]  id        blocks identifier
    /// @param[in]  capacity  blocks capacity
	int  (*set_capacity)(void* param, uint32_t id, uint64_t capacity);

	/// get block by index
    /// @param[in]  param   user-defined parameter
    /// @param[in]  id      blocks identifier
    /// @param[in]  index   block index in blocks
    /// @return     memory pointer
	void* (*at)(void* param, uint32_t id, uint64_t index);
};
```
原型上参考的大致是 STL vector arrary.

然后再所有地方操作 `mov_sample_t` 的地方都使用 `libmov/source/mov-blocks-util.h` 的接口进行操作.