### PR TITLE
fix rtsp muxer getinfo api

### DIFF
--- a/librtsp/source/utils/rtsp-muxer.c
+++ b/librtsp/source/utils/rtsp-muxer.c
@@ -391,7 +391,7 @@ int rtsp_muxer_getinfo(struct rtsp_muxer_t* muxer, int pid, uint16_t* seq, uint3
     pt = &muxer->payloads[pid];
     *sdp = pt->sdp;
     *size = pt->len;
-    rtp_payload_encode_getinfo(pt->rtp.rtp, seq, timestamp);
+    rtp_payload_encode_getinfo(pt->rtp.encoder, seq, timestamp);
     return 0;
 }
 


### PR DESCRIPTION
rtsp_muxer_getinfo遇到段错误问题，修改rtp_payload_encode_getinfo传入参数