### PR TITLE
* fix rtsp server bug

### DIFF
--- a/librtsp/test/rtsp-server-test.cpp
+++ b/librtsp/test/rtsp-server-test.cpp
@@ -533,7 +533,7 @@ static void rtsp_onerror(void* /*param*/, rtsp_server_t* rtsp, int code)
 #if defined(RTSP_SERVER_SOCKET_TEST)
 static int rtsp_send(void* ptr, const void* data, size_t bytes)
 {
-	socket_t socket = *(socket_t*)ptr;
+	socket_t socket = (socket_t)(intptr_t)ptr;
 
 	// TODO: send multiple rtp packet once time
 	return bytes == socket_send(socket, data, bytes, 0) ? 0 : -1;


### PR DESCRIPTION
修复rtsp-server-test在send时获取socket句柄方法不正确导致示例无法运行的bug