### PR TITLE
fix: SDP information in RFC 4566 is indicated to end with CRLF (0x0d0a)

### DIFF
--- a/librtsp/source/sdp/sdp-aac.c
+++ b/librtsp/source/sdp/sdp-aac.c
@@ -18,8 +18,8 @@ int sdp_aac_latm(uint8_t *data, int bytes, const char* proto, unsigned short por
 	// this parameter SHALL NOT be considered as the definitive sampling rate.
 	// profile-level-id --> ISO/IEC 14496-3:2009 audioProfileLevelIndication values
 	static const char* pattern =
-		"m=audio %hu %s %d\n"
-		"a=rtpmap:%d MP4A-LATM/%d/%d\n"
+		"m=audio %hu %s %d\r\n"
+		"a=rtpmap:%d MP4A-LATM/%d/%d\r\n"
 		"a=fmtp:%d profile-level-id=%d;object=%d;cpresent=0;config=";
 
 	int r, n;
@@ -54,8 +54,11 @@ int sdp_aac_latm(uint8_t *data, int bytes, const char* proto, unsigned short por
 		return -ENOMEM; // don't have enough memory
 	n += (int)base16_encode((char*)data + n, config, r);
 
-	if (n < bytes)
-		data[n++] = '\n';
+	if (n + 2 > bytes)
+		return -ENOMEM; // don't have enough memory
+
+	data[n++] = '\r';
+	data[n++] = '\n';
 	return n;
 }
 
@@ -71,8 +74,8 @@ int sdp_aac_generic(uint8_t *data, int bytes, const char* proto, unsigned short 
 	// If an MPEG-4 audio stream is transported, the rate SHOULD be set to the same value as the sampling rate of the audio stream. 
 	// If an MPEG-4 video stream transported, it is RECOMMENDED that the rate be set to 90 kHz.
 	static const char* pattern =
-		"m=audio %hu %s %d\n"
-		"a=rtpmap:%d mpeg4-generic/%d/%d\n"
+		"m=audio %hu %s %d\r\n"
+		"a=rtpmap:%d mpeg4-generic/%d/%d\r\n"
 		"a=fmtp:%d streamtype=5;profile-level-id=%d;mode=AAC-hbr;sizeLength=13;indexLength=3;indexDeltaLength=3;config=";
 
 	int r, n;
@@ -95,8 +98,11 @@ int sdp_aac_generic(uint8_t *data, int bytes, const char* proto, unsigned short 
 	// decoder configuration data AudioSpecificConfig()
 	n += (int)base16_encode((char*)data + n, extra, extra_size);
 
-	if (n < bytes)
-		data[n++] = '\n';
+	if (n + 2 > bytes)
+		return -ENOMEM; // don't have enough memory
+
+	data[n++] = '\r';
+	data[n++] = '\n';
 	return n;
 }
 
@@ -137,9 +143,9 @@ void sdp_aac_test(void)
 	//const unsigned char aachbr[] = { "11B0" }; // 48000/6 streamtype=5; profile-level-id=16
 
 	const uint8_t config[] = { 0x11, 0x90, };
-	//const char* mpeg4_generic_sdp = "m=audio 0 RTP/AVP 96\na=rtpmap:96 mpeg4-generic/48000/2\na=fmtp:96 streamtype=5; profile-level-id=15; mode=AAC-hbr; config=1190; SizeLength=13; IndexLength=3; IndexDeltaLength=3; Profile=1\n";
-	const char* mpeg4_generic_sdp = "m=audio 0 RTP/AVP 96\na=rtpmap:96 mpeg4-generic/48000/2\na=fmtp:96 streamtype=5;profile-level-id=41;mode=AAC-hbr;sizeLength=13;indexLength=3;indexDeltaLength=3;config=1190\n";
-	//const char* mp4a_latm_sdp = "m=audio 0 RTP/AVP 96\na=rtpmap:96 MP4A-LATM/48000/2\na=fmtp:96 profile-level-id=9;object=8;cpresent=0;config=9128B1071070\n";
+	//const char* mpeg4_generic_sdp = "m=audio 0 RTP/AVP 96\r\na=rtpmap:96 mpeg4-generic/48000/2\r\na=fmtp:96 streamtype=5; profile-level-id=15; mode=AAC-hbr; config=1190; SizeLength=13; IndexLength=3; IndexDeltaLength=3; Profile=1\r\n";
+	const char* mpeg4_generic_sdp = "m=audio 0 RTP/AVP 96\r\na=rtpmap:96 mpeg4-generic/48000/2\r\na=fmtp:96 streamtype=5;profile-level-id=41;mode=AAC-hbr;sizeLength=13;indexLength=3;indexDeltaLength=3;config=1190\r\n";
+	//const char* mp4a_latm_sdp = "m=audio 0 RTP/AVP 96\r\na=rtpmap:96 MP4A-LATM/48000/2\r\na=fmtp:96 profile-level-id=9;object=8;cpresent=0;config=9128B1071070\r\n";
 	uint8_t buffer[256];
 	//struct mpeg4_aac_t aac;
 	//int n;

--- a/librtsp/source/sdp/sdp-g7xx.c
+++ b/librtsp/source/sdp/sdp-g7xx.c
@@ -9,12 +9,12 @@
 
 int sdp_g711u(uint8_t *data, int bytes, const char* proto, unsigned short port)
 {
-	static const char* pattern = "m=audio %hu %s 0\n";
+	static const char* pattern = "m=audio %hu %s 0\r\n";
 	return snprintf((char*)data, bytes, pattern, port, proto && *proto ? proto : "RTP/AVP");
 }
 
 int sdp_g711a(uint8_t *data, int bytes, const char* proto, unsigned short port)
 {
-	static const char* pattern = "m=audio %hu %s 8\n";
+	static const char* pattern = "m=audio %hu %s 8\r\n";
 	return snprintf((char*)data, bytes, pattern, port, proto && *proto ? proto : "RTP/AVP");
 }

--- a/librtsp/source/sdp/sdp-h264.c
+++ b/librtsp/source/sdp/sdp-h264.c
@@ -13,8 +13,8 @@
 int sdp_h264(uint8_t *data, int bytes, const char* proto, unsigned short port, int payload, int frequence, const void* extra, int extra_size)
 {
 	static const char* pattern =
-		"m=video %hu %s %d\n"
-		"a=rtpmap:%d H264/90000\n"
+		"m=video %hu %s %d\r\n"
+		"a=rtpmap:%d H264/90000\r\n"
 		"a=fmtp:%d packetization-mode=1;profile-level-id=%02X%02X%02X;sprop-parameter-sets=";
 
 	int r, n;
@@ -47,8 +47,12 @@ int sdp_h264(uint8_t *data, int bytes, const char* proto, unsigned short port, i
 		n += (int)base64_encode((char*)data + n, avc.pps[i].data, avc.pps[i].bytes);
 	}
 
-	if (n < bytes)
-		data[n++] = '\n';
+	if (n + 2 > bytes)
+		return -ENOMEM; // don't have enough memory
+
+	data[n++] = '\r';
+	data[n++] = '\n';
+
 	return n;
 }
 
@@ -81,7 +85,7 @@ int sdp_h264_load(uint8_t* data, int bytes, const char* config)
 #if defined(_DEBUG) || defined(DEBUG)
 void sdp_h264_test(void)
 {
-	const char* sdp = "m=video 0 RTP/AVP 96\na=rtpmap:96 H264/90000\na=fmtp:96 packetization-mode=1;profile-level-id=64001F;sprop-parameter-sets=Z2QAH6zZQFAFumoCGgKAAAADAIAAAB5HjBjL,aO+8sA==\n";
+	const char* sdp = "m=video 0 RTP/AVP 96\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1;profile-level-id=64001F;sprop-parameter-sets=Z2QAH6zZQFAFumoCGgKAAAADAIAAAB5HjBjL,aO+8sA==\r\n";
 	const char* config = "Z2QAH6zZQFAFumoCGgKAAAADAIAAAB5HjBjL,aO+8sA==";
 	static const uint8_t extra[] = { 0x01, 0x64, 0x00, 0x1f, 0xff, 0xe1, 0x00, 0x1b, 0x67, 0x64, 0x00, 0x1f, 0xac, 0xd9, 0x40, 0x50, 0x05, 0xba, 0x6a, 0x02, 0x1a, 0x02, 0x80, 0x00, 0x00, 0x03, 0x00, 0x80, 0x00, 0x00, 0x1e, 0x47, 0x8c, 0x18, 0xcb, 0x01, 0x00, 0x04, 0x68, 0xef, 0xbc, 0xb0 };
 	static const uint8_t ps[] = { 0x00, 0x00, 0x00, 0x1, 0x67, 0x64, 0x00, 0x1f, 0xac, 0xd9, 0x40, 0x50, 0x05, 0xba, 0x6a, 0x02, 0x1a, 0x02, 0x80, 0x00, 0x00, 0x03, 0x00, 0x80, 0x00, 0x00, 0x1e, 0x47, 0x8c, 0x18, 0xcb, 0x00, 0x00, 0x00, 0x1, 0x68, 0xef, 0xbc, 0xb0 };

--- a/librtsp/source/sdp/sdp-h265.c
+++ b/librtsp/source/sdp/sdp-h265.c
@@ -13,8 +13,8 @@
 int sdp_h265(uint8_t *data, int bytes, const char* proto, unsigned short port, int payload, int frequence, const void* extra, int extra_size)
 {
 	static const char* pattern =
-		"m=video %hu %s %d\n"
-		"a=rtpmap:%d H265/90000\n"
+		"m=video %hu %s %d\r\n"
+		"a=rtpmap:%d H265/90000\r\n"
 		"a=fmtp:%d";
 
 	const uint8_t nalu[] = { 32/*vps*/, 33/*sps*/, 34/*pps*/ };
@@ -50,8 +50,11 @@ int sdp_h265(uint8_t *data, int bytes, const char* proto, unsigned short port, i
 		}
 	}
 
-	if(n < bytes) 
-		data[n++] = '\n';
+	if (n + 2 > bytes)
+		return -ENOMEM; // don't have enough memory
+
+	data[n++] = '\r';
+	data[n++] = '\n';
 	return n;
 }
 

--- a/librtsp/source/sdp/sdp-h266.c
+++ b/librtsp/source/sdp/sdp-h266.c
@@ -13,8 +13,8 @@
 int sdp_h266(uint8_t *data, int bytes, const char* proto, unsigned short port, int payload, int frequence, const void* extra, int extra_size)
 {
 	static const char* pattern =
-		"m=video %hu %s %d\n"
-		"a=rtpmap:%d H266/90000\n"
+		"m=video %hu %s %d\r\n"
+		"a=rtpmap:%d H266/90000\r\n"
 		"a=fmtp:%d";
 
 	const uint8_t nalu[] = { 13/*dci*/, 14/*vps*/, 15/*sps*/, 16/*pps*/ };
@@ -50,8 +50,12 @@ int sdp_h266(uint8_t *data, int bytes, const char* proto, unsigned short port, i
 		}
 	}
 
-	if(n < bytes) 
-		data[n++] = '\n';
+	if (n + 2 > bytes)
+		return -ENOMEM; // don't have enough memory
+
+	data[n++] = '\r';
+	data[n++] = '\n';
+	
 	return n;
 }
 

--- a/librtsp/source/sdp/sdp-opus.c
+++ b/librtsp/source/sdp/sdp-opus.c
@@ -16,14 +16,14 @@ int sdp_opus(uint8_t *data, int bytes, const char* proto, unsigned short port, i
 	can be declared via fmtp parameters (both default to mono), but
 	receivers MUST be able to receive and process stereo packets. */
 	static const char* pattern =
-		"m=audio %hu %s %d\n"
-		"a=rtpmap:%d opus/%d/2\n";
+		"m=audio %hu %s %d\r\n"
+		"a=rtpmap:%d opus/%d/2\r\n";
 
 	int n;
 
 	sample_rate = sample_rate ? sample_rate : 48000;
 	n = snprintf((char*)data, bytes, pattern, port, proto && *proto ? proto : "RTP/AVP", payload, payload, sample_rate);
 	if (2 == channel_count)
-		n += snprintf((char*)data + n, bytes - n, "a=fmtp:%d sprop-stereo=1\n", payload);
+		n += snprintf((char*)data + n, bytes - n, "a=fmtp:%d sprop-stereo=1\r\n", payload);
 	return n;
 }


### PR DESCRIPTION
1.在实际测试中，某些客户端拉 RTSP 流，如果 Describe 信令中 SDP 信息以 \n 结尾会解析失败，导致拉流失败。